### PR TITLE
[AI/HS2] Fix clothing overlays failing to load by moving CoordinateType enum

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -24,13 +24,6 @@ using Studio;
 
 namespace KoiClothesOverlayX
 {
-#if AI || HS2
-    public enum CoordinateType
-    {
-        Unknown = 0
-    }
-#endif
-
     public partial class KoiClothesOverlayController : CharaCustomFunctionController
     {
         private const string OverlayDataKey = "Overlays";

--- a/Core_OverlayMods/OverlayStorage.cs
+++ b/Core_OverlayMods/OverlayStorage.cs
@@ -18,13 +18,6 @@ using AIChara;
 
 namespace KoiSkinOverlayX
 {
-#if AI || HS2
-    public enum CoordinateType
-    {
-        Unknown = 0
-    }
-#endif
-
     public class OverlayStorage
     {
         private const string OverlayDataKey = "Lookup";

--- a/Shared_AIHS2/CoordinateTypeShim.cs
+++ b/Shared_AIHS2/CoordinateTypeShim.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Shim required for AI and HS2 since both of these do not have a coord system and this enum is missing.
+/// </summary>
+public enum CoordinateType
+{
+    /// <summary>
+    /// Always use this value.
+    /// </summary>
+    Unknown = 0
+}

--- a/Shared_AIHS2/Shared_AIHS2.projitems
+++ b/Shared_AIHS2/Shared_AIHS2.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Clothes\KoiClothesOverlayController.Hooks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clothes\KoiClothesOverlayGui.Hooks.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CoordinateTypeShim.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Skin\Hooks.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
There might be incompatibilities with other plugins if they reference the CoordinateType enum directly (if they only use the 0 value it should be fine though).